### PR TITLE
feat: Add componenten.nijmegen.nl subdomain

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -102,6 +102,7 @@ const configurations: { [name: string] : Configuration } = {
       region: 'eu-central-1',
     },
     subdomain: 'componenten',
+    alternativeDomains: ['componenten.nijmegen.nl'],
     includePipelineValidationChecks: false,
   },
 };


### PR DESCRIPTION
Adds the domain to configuration, which will create a certificate which adds this subdomain, and uses this cert in the cloudfront configuration.

Fixes https://github.com/GemeenteNijmegen/component-library/issues/15