### PR TITLE
feat: Set CORS headers

### DIFF
--- a/src/CloudfrontDistribution.ts
+++ b/src/CloudfrontDistribution.ts
@@ -138,6 +138,15 @@ export class CloudfrontDistribution extends Construct {
         referrerPolicy: { referrerPolicy: HeadersReferrerPolicy.NO_REFERRER, override: true },
         strictTransportSecurity: { accessControlMaxAge: Duration.days(366), includeSubdomains: true, override: true },
       },
+      corsBehavior: {
+        accessControlAllowMethods: ['GET'],
+        accessControlAllowOrigins: ['*'],
+        accessControlAllowCredentials: false,
+        accessControlAllowHeaders: ['*'],
+        accessControlExposeHeaders: ['*'],
+        accessControlMaxAge: Duration.seconds(0),
+        originOverride: true,
+      },
     });
     return responseHeadersPolicy;
   }


### PR DESCRIPTION
The component library files (.css/.js) are used cross origin, both by websites on the nijmegen.nl-domain and others. Thus we allow all origins

Fixes #42 