### PR TITLE
fix: Use inline scripts

### DIFF
--- a/src/CloudfrontDistribution.ts
+++ b/src/CloudfrontDistribution.ts
@@ -138,6 +138,15 @@ export class CloudfrontDistribution extends Construct {
         referrerPolicy: { referrerPolicy: HeadersReferrerPolicy.NO_REFERRER, override: true },
         strictTransportSecurity: { accessControlMaxAge: Duration.days(366), includeSubdomains: true, override: true },
       },
+      corsBehavior: {
+        accessControlAllowMethods: ['GET'],
+        accessControlAllowOrigins: ['*'],
+        accessControlAllowCredentials: false,
+        accessControlAllowHeaders: ['*'],
+        accessControlExposeHeaders: ['*'],
+        accessControlMaxAge: Duration.seconds(0),
+        originOverride: true,
+      },
     });
     return responseHeadersPolicy;
   }

--- a/src/CloudfrontDistribution.ts
+++ b/src/CloudfrontDistribution.ts
@@ -55,7 +55,7 @@ export class CloudfrontDistribution extends Construct {
     const parameters = new RemoteParameters(this, 'params', {
       path: `${Statics.certificatePath}/`,
       region: 'us-east-1',
-      alwaysUpdate: false,
+      alwaysUpdate: true,
     });
     const certificateArn = parameters.get(Statics.certificateArn);
     return certificateArn;

--- a/src/CloudfrontDistribution.ts
+++ b/src/CloudfrontDistribution.ts
@@ -165,7 +165,7 @@ export class CloudfrontDistribution extends Construct {
       'connect-src \'self\';',
       'form-action \'self\';',
       'style-src \'unsafe-inline\' \'self\' https://fonts.googleapis.com https://fonts.gstatic.com;',
-      'script-src \'self\' https://siteimproveanalytics.com;',
+      'script-src \'unsafe-inline\' \'self\' https://siteimproveanalytics.com;',
       'font-src \'self\' https://fonts.gstatic.com;',
       'img-src \'self\' data: https://*.siteimproveanalytics.io;',
       'object-src \'none\';',


### PR DESCRIPTION
- Allows inline scripts on the component library website, required for it to function.
- Always update cross-region param, hopefully getting the cert-param unstuck in cloudfront.